### PR TITLE
Add PHP subdomain CNAME record

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -27,6 +27,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: 'java.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'kotlin.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'rust.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
+    { subdomain: 'php.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
 
     // Other subdomains
     { subdomain: 'example-server', type: 'CNAME', content: 'ghs.googlehosted.com' },


### PR DESCRIPTION
Finally deployed on https://modelcontextprotocol.github.io/php-sdk/ :raised_hands: 