### PR TITLE
Add go.sdk CNAME record for GitHub Pages

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -23,6 +23,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: 'apps.extensions', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'ts.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'csharp.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
+    { subdomain: 'go.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'py.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'java.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'kotlin.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },


### PR DESCRIPTION
Adds the `go.sdk.modelcontextprotocol.io` CNAME record pointing to GitHub Pages, matching the pattern used by the other SDK subdomains (ts, csharp, py, java, kotlin, rust, php).