### PR TITLE
Remove DMARC aggregate reporting

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -51,7 +51,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     {
       subdomain: '_dmarc',
       type: 'TXT',
-      content: 'v=DMARC1; p=none; rua=mailto:dmarc-reports@modelcontextprotocol.io',
+      content: 'v=DMARC1; p=none',
     },
 
     // Google site verifications


### PR DESCRIPTION
Drops the `rua=` tag from the DMARC record. Reports were going to dmarc-reports@modelcontextprotocol.io, which doesn't have a dedicated mailbox and lands in the catch-all as spam.

Keeps the DMARC policy itself (`v=DMARC1; p=none`) in place.