### PR TITLE
Add TXT records for GitHub org verification (maintainers + SDK subdomains)

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -74,6 +74,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: '_gh-modelcontextprotocol-o.csharp.sdk', type: 'TXT', content: 'b47f9ee5f9' },
     { subdomain: '_gh-modelcontextprotocol-o.maintainers', type: 'TXT', content: 'd673ea837a' },
     { subdomain: '_gh-modelcontextprotocol-o.py.sdk', type: 'TXT', content: 'ded07d9023' },
+    { subdomain: '_gh-modelcontextprotocol-o.ts.sdk', type: 'TXT', content: '7afda7c066' },
     {
       subdomain: '_github-pages-challenge-modelcontextprotocol.blog',
       type: 'TXT',

--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -73,6 +73,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: '_gh-modelcontextprotocol-o.go.sdk', type: 'TXT', content: 'e861b8c825' },
     { subdomain: '_gh-modelcontextprotocol-o.csharp.sdk', type: 'TXT', content: 'b47f9ee5f9' },
     { subdomain: '_gh-modelcontextprotocol-o.java.sdk', type: 'TXT', content: '7be88cc893' },
+    { subdomain: '_gh-modelcontextprotocol-o.kotlin.sdk', type: 'TXT', content: 'afeb00d57b' },
     { subdomain: '_gh-modelcontextprotocol-o.maintainers', type: 'TXT', content: 'd673ea837a' },
     { subdomain: '_gh-modelcontextprotocol-o.py.sdk', type: 'TXT', content: 'ded07d9023' },
     { subdomain: '_gh-modelcontextprotocol-o.ts.sdk', type: 'TXT', content: '7afda7c066' },

--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -71,6 +71,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: '@', type: 'TXT', content: 'czyymtp25a' },
     { subdomain: '_gh-modelcontextprotocol-o', type: 'TXT', content: '8f29e697fc' },
     { subdomain: '_gh-modelcontextprotocol-o.go.sdk', type: 'TXT', content: 'e861b8c825' },
+    { subdomain: '_gh-modelcontextprotocol-o.csharp.sdk', type: 'TXT', content: 'b47f9ee5f9' },
     { subdomain: '_gh-modelcontextprotocol-o.maintainers', type: 'TXT', content: 'd673ea837a' },
     { subdomain: '_gh-modelcontextprotocol-o.py.sdk', type: 'TXT', content: 'ded07d9023' },
     {

--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -72,6 +72,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: '_gh-modelcontextprotocol-o', type: 'TXT', content: '8f29e697fc' },
     { subdomain: '_gh-modelcontextprotocol-o.go.sdk', type: 'TXT', content: 'e861b8c825' },
     { subdomain: '_gh-modelcontextprotocol-o.maintainers', type: 'TXT', content: 'd673ea837a' },
+    { subdomain: '_gh-modelcontextprotocol-o.py.sdk', type: 'TXT', content: 'ded07d9023' },
     {
       subdomain: '_github-pages-challenge-modelcontextprotocol.blog',
       type: 'TXT',

--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -72,6 +72,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: '_gh-modelcontextprotocol-o', type: 'TXT', content: '8f29e697fc' },
     { subdomain: '_gh-modelcontextprotocol-o.go.sdk', type: 'TXT', content: 'e861b8c825' },
     { subdomain: '_gh-modelcontextprotocol-o.csharp.sdk', type: 'TXT', content: 'b47f9ee5f9' },
+    { subdomain: '_gh-modelcontextprotocol-o.java.sdk', type: 'TXT', content: '7be88cc893' },
     { subdomain: '_gh-modelcontextprotocol-o.maintainers', type: 'TXT', content: 'd673ea837a' },
     { subdomain: '_gh-modelcontextprotocol-o.py.sdk', type: 'TXT', content: 'ded07d9023' },
     { subdomain: '_gh-modelcontextprotocol-o.ts.sdk', type: 'TXT', content: '7afda7c066' },

--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -76,6 +76,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: '_gh-modelcontextprotocol-o.kotlin.sdk', type: 'TXT', content: 'afeb00d57b' },
     { subdomain: '_gh-modelcontextprotocol-o.maintainers', type: 'TXT', content: 'd673ea837a' },
     { subdomain: '_gh-modelcontextprotocol-o.py.sdk', type: 'TXT', content: 'ded07d9023' },
+    { subdomain: '_gh-modelcontextprotocol-o.rust.sdk', type: 'TXT', content: 'f8e021d103' },
     { subdomain: '_gh-modelcontextprotocol-o.ts.sdk', type: 'TXT', content: '7afda7c066' },
     {
       subdomain: '_github-pages-challenge-modelcontextprotocol.blog',

--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -71,6 +71,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: '@', type: 'TXT', content: 'czyymtp25a' },
     { subdomain: '_gh-modelcontextprotocol-o', type: 'TXT', content: '8f29e697fc' },
     { subdomain: '_gh-modelcontextprotocol-o.go.sdk', type: 'TXT', content: 'e861b8c825' },
+    { subdomain: '_gh-modelcontextprotocol-o.maintainers', type: 'TXT', content: 'd673ea837a' },
     {
       subdomain: '_github-pages-challenge-modelcontextprotocol.blog',
       type: 'TXT',

--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -75,6 +75,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: '_gh-modelcontextprotocol-o.java.sdk', type: 'TXT', content: '7be88cc893' },
     { subdomain: '_gh-modelcontextprotocol-o.kotlin.sdk', type: 'TXT', content: 'afeb00d57b' },
     { subdomain: '_gh-modelcontextprotocol-o.maintainers', type: 'TXT', content: 'd673ea837a' },
+    { subdomain: '_gh-modelcontextprotocol-o.php.sdk', type: 'TXT', content: '6ae7d8e8ee' },
     { subdomain: '_gh-modelcontextprotocol-o.py.sdk', type: 'TXT', content: 'ded07d9023' },
     { subdomain: '_gh-modelcontextprotocol-o.rust.sdk', type: 'TXT', content: 'f8e021d103' },
     { subdomain: '_gh-modelcontextprotocol-o.ts.sdk', type: 'TXT', content: '7afda7c066' },

--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -71,6 +71,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: '@', type: 'TXT', content: 'czyymtp25a' },
     { subdomain: '_gh-modelcontextprotocol-o', type: 'TXT', content: '8f29e697fc' },
     { subdomain: '_gh-modelcontextprotocol-o.go.sdk', type: 'TXT', content: 'e861b8c825' },
+    { subdomain: '_gh-modelcontextprotocol-o.apps.extensions', type: 'TXT', content: '746ef90c28' },
     { subdomain: '_gh-modelcontextprotocol-o.csharp.sdk', type: 'TXT', content: 'b47f9ee5f9' },
     { subdomain: '_gh-modelcontextprotocol-o.java.sdk', type: 'TXT', content: '7be88cc893' },
     { subdomain: '_gh-modelcontextprotocol-o.kotlin.sdk', type: 'TXT', content: 'afeb00d57b' },


### PR DESCRIPTION
Adds GitHub org verification TXT records:

- `_gh-modelcontextprotocol-o.apps.extensions` → `746ef90c28`
- `_gh-modelcontextprotocol-o.csharp.sdk` → `b47f9ee5f9`
- `_gh-modelcontextprotocol-o.java.sdk` → `7be88cc893`
- `_gh-modelcontextprotocol-o.kotlin.sdk` → `afeb00d57b`
- `_gh-modelcontextprotocol-o.maintainers` → `d673ea837a`
- `_gh-modelcontextprotocol-o.php.sdk` → `6ae7d8e8ee`
- `_gh-modelcontextprotocol-o.py.sdk` → `ded07d9023`
- `_gh-modelcontextprotocol-o.rust.sdk` → `f8e021d103`
- `_gh-modelcontextprotocol-o.ts.sdk` → `7afda7c066`