### PR TITLE
Add TXT record for Google site verification

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -66,6 +66,11 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
       type: 'TXT',
       content: 'google-site-verification=UI0Tjq-ecUgNu3kFATkW87qcabX6kTljsbYjms2-FdQ',
     },
+    {
+      subdomain: '@',
+      type: 'TXT',
+      content: 'google-site-verification=FhpMfMf1V9X1n7NSWPcUcb7cKXtUElzM8cbEBm3WXd4',
+    },
 
     // Other TXT verifications
     { subdomain: '@', type: 'TXT', content: 'czyymtp25a' },


### PR DESCRIPTION
## Summary
- Add a `google-site-verification` TXT record at the root domain (`@`) to verify domain ownership with Google

## Test plan
- [x] CI passes
- [x] Confirm TXT record resolves after deployment: `dig TXT <domain> +short | grep google-site-verification`
- [ ] Verify domain ownership in Google Search Console