### PR TITLE
Add Ruby SDK domain

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -29,6 +29,7 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: 'kotlin.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'rust.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'php.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
+    { subdomain: 'ruby.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
 
     // Other subdomains
     { subdomain: 'example-server', type: 'CNAME', content: 'ghs.googlehosted.com' },


### PR DESCRIPTION
https://modelcontextprotocol.github.io/ruby-sdk/ will become https://ruby.sdk.modelcontextprotocol.io/.
