### PR TITLE
Remove guildbridge CNAME (managed by Worker Custom Domain)

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -34,11 +34,8 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     // Other subdomains
     { subdomain: 'example-server', type: 'CNAME', content: 'ghs.googlehosted.com' },
     { subdomain: 'meet', type: 'CNAME', content: 'mcp.meetable.org' },
-    {
-      subdomain: 'guildbridge',
-      type: 'CNAME',
-      content: 'guildbridge.modelcontextprotocol.io.cdn.cloudflare.net',
-    },
+    // guildbridge.modelcontextprotocol.io is managed by a Worker Custom Domain binding
+    // (read-only record, not manageable via DnsRecord)
 
     // MX record for Google Workspace
     { subdomain: '@', type: 'MX', content: 'smtp.google.com', priority: 1 },


### PR DESCRIPTION
## Summary
- Removes the `guildbridge` CNAME entry from `records.ts`
- This subdomain is bound as a Cloudflare Worker Custom Domain, which auto-creates a read-only DNS record not manageable via the DNS API
- Deploy has been failing since #13 with Cloudflare error 9059 (`Invalid CNAME target. Only DNS Only zones can point to partial suffixes`)
- The record stays live — it's managed by the Worker binding, not this Pulumi stack

## Test plan
- [ ] CI passes
- [ ] Deploy workflow succeeds on merge (no resources to create/destroy for guildbridge)
- [ ] `dig guildbridge.modelcontextprotocol.io` still resolves after deploy