### PR TITLE
Remove ruby.sdk CNAME due to domain squatting

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -29,7 +29,6 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: 'kotlin.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'rust.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'php.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
-    { subdomain: 'ruby.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
 
     // Other subdomains
     { subdomain: 'example-server', type: 'CNAME', content: 'ghs.googlehosted.com' },


### PR DESCRIPTION
Removes the `ruby.sdk` CNAME record. The subdomain was being squatted on GitHub Pages before org domain verification completed.

The `_gh-modelcontextprotocol-o.ruby.sdk` TXT verification record (added in #16) is intentionally kept — once that propagates and the domain is verified in org settings, only repos under this org will be able to claim `ruby.sdk.modelcontextprotocol.io` as a Pages custom domain, at which point the CNAME can be safely re-added.