### PR TITLE
Remove go.sdk CNAME due to domain hijacking

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -23,7 +23,6 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: 'apps.extensions', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'ts.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'csharp.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
-    { subdomain: 'go.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'py.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'java.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'kotlin.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },


### PR DESCRIPTION
Removes the `go.sdk` CNAME record — the subdomain has been hijacked on GitHub Pages by an account outside the org.

The `_gh-modelcontextprotocol-o.go.sdk` TXT verification record is kept. Once the parent `sdk` domain verification (#19) propagates and is confirmed in org settings, all `*.sdk` subdomains will be protected from outside takeover and this CNAME can be safely re-added.

Same mitigation as #18 (ruby.sdk).