### PR TITLE
Remove py.sdk CNAME — dangling and exposed to takeover

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -23,7 +23,6 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: 'apps.extensions', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'ts.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'csharp.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
-    { subdomain: 'py.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'java.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'kotlin.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'rust.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },


### PR DESCRIPTION
The `py.sdk` CNAME is currently dangling: it resolves to GitHub Pages, serves the GitHub 404 page, and `modelcontextprotocol/python-sdk` has `cname: null` in its Pages config — i.e. no org repo claims it. This is the identical posture `ruby.sdk` (#18) and `go.sdk` (#20) were in when hijacked.

Removing the CNAME until proper Pages domain verification is in place.

**Note on verification:** the `_gh-modelcontextprotocol-o.*` TXT records added in #16/#19 are GitHub *org-profile* domain verification (the "Verified" badge), not GitHub *Pages* domain verification. Pages takeover protection requires a separate `_github-pages-challenge-modelcontextprotocol.*` TXT generated from **Org Settings → Pages → Add a domain**, which currently exists only for `blog`. A follow-up PR will add the correct records once those codes are generated.