### PR TITLE
Add Pages domain verification for sdk and restore go/ruby SDK CNAMEs

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -88,10 +88,19 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: '_gh-modelcontextprotocol-o.rust.sdk', type: 'TXT', content: 'f8e021d103' },
     { subdomain: '_gh-modelcontextprotocol-o.sdk', type: 'TXT', content: '9469faa78d' },
     { subdomain: '_gh-modelcontextprotocol-o.ts.sdk', type: 'TXT', content: '7afda7c066' },
+
+    // GitHub Pages domain verification — protects the domain and its immediate
+    // subdomains from being claimed as a Pages custom domain by accounts outside
+    // this org. Generated under Org Settings → Pages → Add a verified domain.
     {
       subdomain: '_github-pages-challenge-modelcontextprotocol.blog',
       type: 'TXT',
       content: '1d4b431f4dc23d532fd33da4596bcf',
+    },
+    {
+      subdomain: '_github-pages-challenge-modelcontextprotocol.sdk',
+      type: 'TXT',
+      content: '4ef0d3c1056a365f0f01b510350fb6',
     },
   ],
   'modelcontextprotocol.net': [{ subdomain: '@', type: 'A', content: '76.76.21.21' }],


### PR DESCRIPTION
Adds the `_github-pages-challenge-modelcontextprotocol.sdk` TXT record for GitHub **Pages** domain verification (Org Settings → Pages → Add a verified domain).

Once this deploys and is verified in org settings, it protects `sdk.modelcontextprotocol.io` **and all immediate `*.sdk` subdomains** from being claimed as a Pages custom domain by any account outside the modelcontextprotocol org — the durable fix for the takeovers that prompted #18 and #20.

This is distinct from the `_gh-modelcontextprotocol-o.*` records (org-profile "Verified" badge), which do not provide Pages takeover protection.

Additional Pages-verification records (apex, `extensions`) can be appended to this PR as the codes are generated.