### PR TITLE
Restore go.sdk and ruby.sdk CNAMEs

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -23,11 +23,13 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: 'apps.extensions', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'ts.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'csharp.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
+    { subdomain: 'go.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'py.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'java.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'kotlin.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'rust.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
     { subdomain: 'php.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
+    { subdomain: 'ruby.sdk', type: 'CNAME', content: 'modelcontextprotocol.github.io' },
 
     // Other subdomains
     { subdomain: 'example-server', type: 'CNAME', content: 'ghs.googlehosted.com' },


### PR DESCRIPTION
Restores the `go.sdk` and `ruby.sdk` CNAMEs that were removed in #20 and #18 after takeover.

**Safety status as of this PR:**
- `go.sdk` — `modelcontextprotocol/go-sdk` repo has `go.sdk.modelcontextprotocol.io` set as its Pages custom domain, so the CNAME is claimed on deploy. ✅
- `ruby.sdk` — `modelcontextprotocol/ruby-sdk` repo currently has `cname: null`. **Before merging this**, either set `ruby.sdk.modelcontextprotocol.io` as that repo's Pages custom domain, or confirm the `sdk` Pages-verification from #22 shows Verified in Org Settings → Pages. Otherwise this re-creates the dangling state. ⚠️