### PR TITLE
Add tasks.extensions CNAME for MCP Tasks Extension docs

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -34,6 +34,8 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     // Other subdomains
     { subdomain: 'example-server', type: 'CNAME', content: 'ghs.googlehosted.com' },
     { subdomain: 'meet', type: 'CNAME', content: 'mcp.meetable.org' },
+    // MCP Tasks Extension docs, hosted on Cloudflare Pages (modelcontextprotocol/ext-tasks)
+    { subdomain: 'tasks.extensions', type: 'CNAME', content: 'ext-tasks.pages.dev' },
     // guildbridge.modelcontextprotocol.io is managed by a Worker Custom Domain binding
     // (read-only record, not manageable via DnsRecord)
 


### PR DESCRIPTION
Point tasks.extensions.modelcontextprotocol.io at the Cloudflare Pages
deployment (ext-tasks.pages.dev) that serves the MCP Tasks Extension
documentation site.