### PR TITLE
POC: Cloudflare edge cache for registry GET /v0/servers (registry #1323)

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,97 @@
+import * as pulumi from '@pulumi/pulumi';
+import * as cloudflare from '@pulumi/cloudflare';
+
+// ---------------------------------------------------------------------------
+// Edge caching for the MCP registry's read-heavy list endpoint (POC).
+//
+// Context: registry issue #1323 found that GET /v0/servers cannot absorb high
+// request volumes — above ~300 RPS the service spikes on CPU, goroutines
+// (8k–12k at peak) and heap, and requests time out waiting on the Postgres
+// queue. The DB queries themselves are not the bottleneck; the service just
+// can't soak up the request volume. The maintainer's recommended fix is a CDN
+// caching layer in front of the registry, and Cloudflare is a natural fit
+// because modelcontextprotocol.io DNS is already managed here via the
+// Cloudflare provider.
+//   https://github.com/modelcontextprotocol/registry/issues/1323#issuecomment-4745822992
+//
+// This file adds a Cloudflare cache ruleset that makes
+//   GET https://registry.modelcontextprotocol.io/v0/servers
+// cacheable at the edge. The `registry` DNS record is switched to proxied
+// (orange-cloud) in src/config/records.ts so this traffic actually flows
+// through Cloudflare — a cache rule has no effect on a DNS-only record.
+//
+// NOTE (POC): the defaults below are intentionally conservative and meant as a
+// starting point for maintainer discussion. The knobs most worth tuning are
+// EDGE_TTL_SECONDS (staleness vs. origin-offload) and the cache-key query
+// params. See the PR description for the proxying considerations (origin TLS,
+// real-client-IP headers, and cache invalidation on registry writes).
+// ---------------------------------------------------------------------------
+
+const config = new pulumi.Config();
+const accountId = config.require('cloudflareAccountId');
+
+// The zone that hosts the registry, resolved the same way src/dns.ts resolves
+// zones for DNS records.
+const REGISTRY_ZONE = 'modelcontextprotocol.io';
+
+// Public API hostname that serves /v0/servers.
+const REGISTRY_HOST = 'registry.modelcontextprotocol.io';
+
+// Conservative edge TTL. The registry origin does not currently emit
+// Cache-Control headers, so we override the origin and cache for a short
+// window. Even 60s of edge caching collapses a flood of identical list
+// requests into a single origin hit per page. Tune upward once maintainers are
+// comfortable with the resulting staleness (and/or pair with active cache
+// purges on registry writes — see PR description).
+const EDGE_TTL_SECONDS = 60;
+
+const registryZone = cloudflare.getZoneOutput({
+  filter: {
+    name: REGISTRY_ZONE,
+    account: { id: accountId },
+  },
+});
+
+// Cache rule in the http_request_cache_settings phase for the registry list
+// endpoint. A zone may only have one ruleset per phase, so this single
+// resource owns the registry's cache configuration.
+export const registryCacheRuleset = new cloudflare.Ruleset('registry-cache', {
+  zoneId: registryZone.id,
+  name: 'Registry edge cache',
+  description: 'Edge-cache GET /v0/servers on the registry (registry issue #1323).',
+  kind: 'zone',
+  phase: 'http_request_cache_settings',
+  rules: [
+    {
+      ref: 'cache_v0_servers',
+      description: 'Cache GET /v0/servers list responses at the edge, keyed by pagination params.',
+      // Scope narrowly: only the read-heavy list endpoint on the registry host,
+      // GET only. Detail routes (/v0/servers/{name}) and writes are untouched.
+      expression: `(http.host eq "${REGISTRY_HOST}" and http.request.method eq "GET" and http.request.uri.path eq "/v0/servers")`,
+      action: 'set_cache_settings',
+      actionParameters: {
+        // Force the response to be cacheable even though the origin currently
+        // sends no Cache-Control header.
+        cache: true,
+        edgeTtl: {
+          mode: 'override_origin',
+          default: EDGE_TTL_SECONDS,
+          // Never cache error responses — only successful/redirect pages should
+          // be served from the edge. value 0 == "no-cache".
+          statusCodeTtls: [{ statusCodeRange: { from: 400, to: 599 }, value: 0 }],
+        },
+        // Build the cache key from only the pagination params so each page
+        // caches as a distinct entry, while unknown/tracking query params don't
+        // fragment the cache (or let an attacker blow past it with junk params).
+        cacheKey: {
+          ignoreQueryStringsOrder: true,
+          customKey: {
+            queryString: {
+              include: { lists: ['cursor', 'limit'] },
+            },
+          },
+        },
+      },
+    },
+  ],
+});

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -64,7 +64,7 @@ export const registryCacheRuleset = new cloudflare.Ruleset('registry-cache', {
   rules: [
     {
       ref: 'cache_v0_servers',
-      description: 'Cache GET /v0/servers list responses at the edge, keyed by pagination params.',
+      description: 'Cache GET /v0/servers list responses at the edge, keyed by its query params.',
       // Scope narrowly: only the read-heavy list endpoint on the registry host,
       // GET only. Detail routes (/v0/servers/{name}) and writes are untouched.
       expression: `(http.host eq "${REGISTRY_HOST}" and http.request.method eq "GET" and http.request.uri.path eq "/v0/servers")`,
@@ -80,14 +80,21 @@ export const registryCacheRuleset = new cloudflare.Ruleset('registry-cache', {
           // be served from the edge. value 0 == "no-cache".
           statusCodeTtls: [{ statusCodeRange: { from: 400, to: 599 }, value: 0 }],
         },
-        // Build the cache key from only the pagination params so each page
-        // caches as a distinct entry, while unknown/tracking query params don't
-        // fragment the cache (or let an attacker blow past it with junk params).
+        // Build the cache key from exactly the query params that change the
+        // /v0/servers response body, so each distinct page/filter caches as its
+        // own entry — while unknown/tracking params don't fragment the cache (or
+        // let someone blow past it with junk params). These mirror the endpoint's
+        // ListServersInput: cursor, limit (paging) plus the search/version/
+        // updated_since/include_deleted filters. Keep this list in sync if the
+        // registry adds new query params, otherwise responses that differ only by
+        // a new param would be incorrectly served from the same cache entry.
         cacheKey: {
           ignoreQueryStringsOrder: true,
           customKey: {
             queryString: {
-              include: { lists: ['cursor', 'limit'] },
+              include: {
+                lists: ['cursor', 'limit', 'search', 'version', 'updated_since', 'include_deleted'],
+              },
             },
           },
         },

--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -9,7 +9,17 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: 'spec', type: 'A', content: '76.76.21.21' },
 
     // Registry
-    { subdomain: 'registry', type: 'CNAME', content: 'prod.registry.modelcontextprotocol.io' },
+    // `registry` is the public API hostname (serves GET /v0/servers). It is
+    // proxied through Cloudflare (orange-cloud) so the edge cache rule defined
+    // in src/cache.ts can absorb read traffic — see registry issue #1323.
+    // `prod.registry` stays DNS-only (grey) so origin/staging remain directly
+    // reachable; the proxied CNAME flattens onto its A record at the edge.
+    {
+      subdomain: 'registry',
+      type: 'CNAME',
+      content: 'prod.registry.modelcontextprotocol.io',
+      proxied: true,
+    },
     { subdomain: 'prod.registry', type: 'A', content: '34.61.200.254' },
     { subdomain: 'staging.registry', type: 'A', content: '35.222.36.75' },
     { subdomain: 'grafana.prod.registry', type: 'A', content: '34.61.200.254' },
@@ -117,4 +127,8 @@ interface DnsRecordConfig {
   content: string;
   ttl?: number;
   priority?: number;
+  // Whether to proxy this record through Cloudflare (orange-cloud). Defaults to
+  // false (DNS-only / grey-cloud). Only proxied records can be cached, have WAF
+  // applied, etc. at the Cloudflare edge.
+  proxied?: boolean;
 }

--- a/src/dns.ts
+++ b/src/dns.ts
@@ -29,8 +29,9 @@ for (const [domain, records] of Object.entries(DNS_RECORDS)) {
       name: record.subdomain,
       type: record.type,
       content: record.content,
+      // Cloudflare requires TTL to be 1 ("automatic") for proxied records.
       ttl: record.ttl ?? 1,
-      proxied: false,
+      proxied: record.proxied ?? false,
       priority: record.priority,
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './dns';
+export * from './cache';


### PR DESCRIPTION
🤖 **Proof of concept authored by Claude.** This is an exploratory draft for maintainer review, not a production-ready change. I cannot run `pulumi preview`/`make up` (GCP + Pulumi passphrase are maintainer-only secrets), so this is validated only by the secret-free checks below — please treat the chosen defaults as starting points for discussion.

## Motivation

The registry's read-heavy list endpoint `GET /v0/servers` has a throughput problem. In registry issue [#1323](https://github.com/modelcontextprotocol/registry/issues/1323), maintainer **@pree-dew** load-tested ~19k server entries and [reported](https://github.com/modelcontextprotocol/registry/issues/1323#issuecomment-4745822992) that above ~300 RPS, CPU, goroutines (8k–12k at peak) and heap spike sharply and requests time out waiting on the Postgres queue — **the DB queries aren't the bottleneck, the service just can't absorb the request volume.** The recommended fix is a **CDN caching layer** in front of the registry. Three options were floated (Google Cloud CDN, Cloudflare, Fastly); **Cloudflare** is the natural fit because `modelcontextprotocol.io` DNS is already managed here via the Cloudflare provider.

This PR is a POC of the Cloudflare option, as IaC in this repo, to give maintainers something concrete to evaluate.

## What this changes

Two pieces:

1. **Proxy the registry hostname through Cloudflare.** Records here default to DNS-only (grey cloud); Cloudflare can only cache traffic for a **proxied** (orange-cloud) record. I added a per-record `proxied?: boolean` flag to the record config (`src/dns.ts` now honors `record.proxied ?? false`, preserving today's grey-cloud default for every other record) and set `proxied: true` on the `registry` CNAME — the public hostname that serves `/v0/servers`. `prod.registry` stays grey so the origin/staging remain directly reachable; the proxied CNAME flattens onto its in-zone A record at the edge.

2. **Add a Cloudflare cache rule** (`src/cache.ts`, new `cloudflare.Ruleset` in the `http_request_cache_settings` phase) that makes `GET /v0/servers` cacheable at the edge:
   - **Match scope:** `http.host eq "registry.modelcontextprotocol.io" and http.request.method eq "GET" and http.request.uri.path eq "/v0/servers"` — only the list endpoint, GET only. Detail routes (`/v0/servers/{name}`) and writes are untouched.
   - **Edge TTL:** `override_origin`, **60s** (the origin sends no `Cache-Control` today, so we override it). Error responses (4xx/5xx) are explicitly never served from cache.
   - **Cache key:** restricted to exactly the query params that change the `/v0/servers` response body — `cursor`, `limit`, `search`, `version`, `updated_since`, `include_deleted` (these mirror the endpoint's `ListServersInput`), order-insensitive. Distinct pages/filters cache separately; unknown/tracking query params don't fragment the cache (or let someone blow past it with junk params).

## Defaults chosen (and the knobs to tune)

| Knob | This POC | Why / how to tune |
|------|----------|-------------------|
| Edge TTL | 60s | Conservative — even 60s collapses a flood of identical requests into one origin hit per page/filter. Raise it for more origin offload once you're comfortable with staleness. |
| Cache-key query params | `cursor`, `limit`, `search`, `version`, `updated_since`, `include_deleted` | The full set of response-affecting params on the list endpoint. **Keep in sync** if the registry adds new query params — a new param not listed here would cause responses that differ only by that param to share a cache entry. |
| Cached methods/paths | `GET /v0/servers` only | Deliberately narrow for a POC. Could extend to other safe read endpoints. |
| Error caching | disabled (4xx/5xx) | Avoids serving a transient error from the edge. |

## Open questions / considerations for reviewers

Proxying the hostname (not just the cache rule) introduces a few things worth weighing:

- **Origin TLS:** once proxied, Cloudflare terminates TLS at the edge and re-connects to origin. The zone SSL mode should be **Full (strict)** with the origin presenting a valid cert for `registry.modelcontextprotocol.io`; otherwise expect TLS errors. This is a zone-level setting not managed in this repo.
- **Real client IP:** the origin will see Cloudflare IPs. Any IP-based logging/rate-limiting in the registry must read `CF-Connecting-IP` (or `X-Forwarded-For`) instead of the socket peer.
- **Cache invalidation on writes:** with a 60s TTL, a freshly published server can be invisible in the cached list for up to the TTL. Options: keep the TTL short (this POC), or have the registry issue a targeted Cloudflare cache purge on publish. Worth a follow-up discussion.
- **One ruleset per phase:** a zone can hold only one `http_request_cache_settings` ruleset; this resource owns it. If other cache rules are added later they should live in the same ruleset.

## Verification

I could not run cloud-auth'd steps (`pulumi preview` / `make up`) — those need `GCP_PROD_SERVICE_ACCOUNT_KEY` / `PULUMI_PROD_PASSPHRASE`, which aren't available to a fork draft. The `Deploy` workflow only runs on push to `main`, so it does not run on this PR. I ran the same secret-free checks `.github/workflows/ci.yml` runs:

- [x] `npm ci` — clean install (260 packages)
- [x] `npm run build` (`tsc`, strict) — **clean, exit 0.** This typechecks the Pulumi program against the `@pulumi/cloudflare` v6.13.0 resource schema, so the `Ruleset` / cache-key / edge-TTL shapes are validated.
- [x] `npm run format:check` (`prettier --check .`) — **clean,** "All matched files use Prettier code style!"
- [x] **CI green** on this PR — the `Build and Typecheck` job (no secrets) passed in ~31s.
- [x] **Independent fresh-eyes review performed** (separate adversarial pass against the provider v6 schema and the registry's actual endpoint). It verified the Ruleset shape, enum values, and Wirefilter expression are correct, and caught one real bug: the cache key originally keyed only on `cursor`/`limit`, which would conflate responses that differ by `search`/`version`/`updated_since`/`include_deleted`. **Fixed** by keying on all six response-affecting params (commit in this PR); re-ran `tsc`/`prettier` clean and re-confirmed CI.

Cloud-auth CI jobs are expected to be skipped/absent for a fork draft.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
