### PR TITLE
Add CNAME record for server-card.extensions

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -36,6 +36,9 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: 'meet', type: 'CNAME', content: 'mcp.meetable.org' },
     // MCP Tasks Extension docs, hosted on Cloudflare Pages (modelcontextprotocol/ext-tasks)
     { subdomain: 'tasks.extensions', type: 'CNAME', content: 'ext-tasks.pages.dev' },
+    // MCP Server Card Extension docs, hosted on Cloudflare Pages (modelcontextprotocol/ext-server-card)
+    { subdomain: 'server-card.extensions', type: 'CNAME', content: 'server-card.pages.dev' },
+    https://github.com/modelcontextprotocol/ext-server-card
     // guildbridge.modelcontextprotocol.io is managed by a Worker Custom Domain binding
     // (read-only record, not manageable via DnsRecord)
 

--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -38,7 +38,6 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: 'tasks.extensions', type: 'CNAME', content: 'ext-tasks.pages.dev' },
     // MCP Server Card Extension docs, hosted on Cloudflare Pages (modelcontextprotocol/ext-server-card)
     { subdomain: 'server-card.extensions', type: 'CNAME', content: 'server-card.pages.dev' },
-    https://github.com/modelcontextprotocol/ext-server-card
     // guildbridge.modelcontextprotocol.io is managed by a Worker Custom Domain binding
     // (read-only record, not manageable via DnsRecord)
 


### PR DESCRIPTION
Add CNAME record for server-card.extensions.

## Motivation and Context

Server Cards are now officially approved as an extension. This is a pre-requisite to adding a dedicated sub-page to modelcontextprotocol.io

## How Has This Been Tested?
It has not

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
