### PR TITLE
Note securityroom Worker Custom Domain

### DIFF
--- a/src/config/records.ts
+++ b/src/config/records.ts
@@ -38,6 +38,8 @@ export const DNS_RECORDS: Record<string, DnsRecordConfig[]> = {
     { subdomain: 'tasks.extensions', type: 'CNAME', content: 'ext-tasks.pages.dev' },
     // guildbridge.modelcontextprotocol.io is managed by a Worker Custom Domain binding
     // (read-only record, not manageable via DnsRecord)
+    // securityroom.modelcontextprotocol.io is managed by a Worker Custom Domain binding
+    // (modelcontextprotocol/security-room; read-only record, not manageable via DnsRecord)
 
     // MX record for Google Workspace
     { subdomain: '@', type: 'MX', content: 'smtp.google.com', priority: 1 },


### PR DESCRIPTION
`securityroom.modelcontextprotocol.io` is served by the Worker in modelcontextprotocol/security-room and attached as a Workers Custom Domain, so Cloudflare creates and owns the DNS record and it can't be managed as a `DnsRecord` here. This adds a comment alongside the existing `guildbridge` note so the hostname is discoverable from this repo. No resource changes; `pulumi preview` should show no diff.